### PR TITLE
入力方法をインスペクタから設定できるようにした

### DIFF
--- a/Ami-gyo2/Assets/Scenes/Ami-gyo.unity
+++ b/Ami-gyo2/Assets/Scenes/Ami-gyo.unity
@@ -570,6 +570,21 @@ Prefab:
       value: 
       objectReference: {fileID: 1405165539944386, guid: 5fde195cbc6392642ac630464d75905a,
         type: 2}
+    - target: {fileID: 114174085757769560, guid: efffd26b78db46c4aa0ff20c456daf90,
+        type: 2}
+      propertyPath: portName
+      value: COM3
+      objectReference: {fileID: 0}
+    - target: {fileID: 114174085757769560, guid: efffd26b78db46c4aa0ff20c456daf90,
+        type: 2}
+      propertyPath: baudRate
+      value: 9600
+      objectReference: {fileID: 0}
+    - target: {fileID: 114174085757769560, guid: efffd26b78db46c4aa0ff20c456daf90,
+        type: 2}
+      propertyPath: inputType
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: efffd26b78db46c4aa0ff20c456daf90, type: 2}
   m_IsPrefabAsset: 0

--- a/Ami-gyo2/Assets/Scenes/Ami-gyo.unity
+++ b/Ami-gyo2/Assets/Scenes/Ami-gyo.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657868, g: 0.49641263, b: 0.57481706, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -368,7 +368,7 @@ Camera:
   near clip plane: 0.3
   far clip plane: 1000
   field of view: 60
-  orthographic: 0
+  orthographic: 1
   orthographic size: 5
   m_Depth: -1
   m_CullingMask:
@@ -542,7 +542,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4711739468354266, guid: efffd26b78db46c4aa0ff20c456daf90, type: 2}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -4.5
       objectReference: {fileID: 0}
     - target: {fileID: 4711739468354266, guid: efffd26b78db46c4aa0ff20c456daf90, type: 2}
       propertyPath: m_LocalRotation.x
@@ -564,6 +564,12 @@ Prefab:
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 114174085757769560, guid: efffd26b78db46c4aa0ff20c456daf90,
+        type: 2}
+      propertyPath: netPrefab
+      value: 
+      objectReference: {fileID: 1405165539944386, guid: 5fde195cbc6392642ac630464d75905a,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: efffd26b78db46c4aa0ff20c456daf90, type: 2}
   m_IsPrefabAsset: 0

--- a/Ami-gyo2/Assets/Scripts/Ship/Shooter.cs
+++ b/Ami-gyo2/Assets/Scripts/Ship/Shooter.cs
@@ -5,16 +5,37 @@ using UnityEngine;
 
 namespace Amigyo.Ship
 {
+    public enum InputType
+    {
+        MouseInput,
+        DeviceInput
+    }
+
     public class Shooter : MonoBehaviour
     {
         //  Zenjectにfield-injectionさせる。
-        private IInputProvider inputProvider = new MouseInputProvider();
+        private IInputProvider inputProvider;
 
         [SerializeField]
         private GameObject netPrefab;
 
+        [SerializeField]
+        private InputType inputType;
+
+        [SerializeField]
+        private string portName;
+
+        [SerializeField]
+        private int baudRate;
+
         private void Start()
         {
+            //  IInputProviderを自分でインジェクションする。
+            //  規模が小さいため、DIコンテナは使わない。
+            this.inputProvider = (this.inputType == InputType.DeviceInput && this.portName != null)
+                ? new DeviceInputProvider(this.portName, this.baudRate) as IInputProvider
+                : new MouseInputProvider() as IInputProvider;
+
             //  角度が変化したときの処理。
             this.inputProvider.Angle.Subscribe(this.OnAngleChanged).AddTo(this);
 


### PR DESCRIPTION
入力方法を設定できるようにした。
#23 

![2019y01m08d_142035782](https://user-images.githubusercontent.com/11826756/50811290-03e30880-1351-11e9-8501-597fd042fa49.png)

`MouseInput` に設定すると、マウスの移動でShooterの角度を変化させ、クリックでNetを発射するようになる。  
`DeviceInput` に設定すると、可変抵抗の回転でShooterの角度を変化させ、タクトスイッチでNetを発射するようになる。

InspectorでCOMポートの番号をBaudRateの設定が必要。  
(DeviceInputのみ。)