### PR TITLE
魚の向きの設定方法を変更

### DIFF
--- a/Ami-gyo2/Assets/Params/SpawnerInfos/Standard.asset
+++ b/Ami-gyo2/Assets/Params/SpawnerInfos/Standard.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Name: Standard
   m_EditorClassIdentifier: 
   fishPrefabs:
-  - {fileID: 1361852580158066, guid: fcb74b1dd82c04f4bb445d450d5c53b7, type: 2}
-  - {fileID: 1569767388231130, guid: 5101f8c74bf69224dbb0bae6a3abe397, type: 2}
   - {fileID: 1234918367267080, guid: d6c7ebe8a1f1d1f45b109cf679f4a4c0, type: 2}
   - {fileID: 1124833601402256, guid: 35226364fc5f224499fe6f32ffd68b0c, type: 2}
+  - {fileID: 1026288934305244, guid: bba944d72f8f1cf4da1fcef91da55376, type: 2}
+  - {fileID: 1569767388231130, guid: 5101f8c74bf69224dbb0bae6a3abe397, type: 2}


### PR DESCRIPTION
#37 

4フレーム前から現在までの変位ベクトルを方向ベクトルとして使うようにした。

```CSharp
//  4フレーム前の地点からの変位ベクトルを魚の向きとする。
this.FixedUpdateAsObservable()
    .Select(_ => this.transform.position)
    .Buffer(4, 1)
    .Select(positions => positions.Last() - positions.First())
    .Select(delta => Quaternion.LookRotation(delta.normalized))
    .Subscribe(rot => this.transform.rotation = rot)
    .AddTo(this);
```